### PR TITLE
Improve ssh-keyscan

### DIFF
--- a/ZIGI.V1R1.EXEC/ZIGI
+++ b/ZIGI.V1R1.EXEC/ZIGI
@@ -548,10 +548,11 @@ Work_With_Repo:
         else do
           parse var origin guser '@' host ':' rest
           cmd = 'touch 'home'/.ssh/known_hosts && '
-          cmd = cmd 'ssh-keyscan -t rsa,dsa 'host
-          cmd = cmd ' 2>&1 | sort -u - 'home'/.ssh/known_hosts >'
-          cmd = cmd ' 'home'/.ssh/tmp_hosts && '
-          cmd = cmd 'mv 'home'/.ssh/tmp_hosts 'home'/.ssh/known_hosts'
+          cmd = cmd 'if ! grep 'host
+          cmd = cmd home'/.ssh/known_hosts >/dev/null;'
+          cmd = cmd 'then ssh-keyscan -t rsa,dsa 'host
+          cmd = cmd ' 2>/dev/null >> 'home'/.ssh/known_hosts ;'
+          cmd = cmd 'fi'
           x = bpxwunix(cmd,,so.,se.)
           cmd = 'cd' localrep'/'zigirep
           x = docmd(cmd '&& git remote add origin 'origin)


### PR DESCRIPTION
**I did not test this with zigi**.
My 1090 has no access to the Internet yet.

The code should run something like this: 
`touch /home/zdouser/.ssh/known_hosts &&  if ! grep git.host.name /home/zdouser/.ssh/known_hosts >/dev/null; then ssh-keyscan -t rsa,dsa git.host.name  2>/dev/null >> /home/zdouser/.ssh/known_hosts ; fi
`

If you try to add a host again, the `grep` will put a line on the standard output, I don't know if this can be a problem for `docmd()`.