### PR TITLE
Improve username and email setup

### DIFF
--- a/ZIGI.PANELS/ZIGISET
+++ b/ZIGI.PANELS/ZIGISET
@@ -10,16 +10,16 @@
 +
 %Git Defaults (used at Commit time):
 +
-+  user.name  :@zigiuid                                         +
-+  user.email :@zigimail                                        +
++  user.name  :@zigiuid                                                        +
++  user.email :@zigimail                                                       +
 +
 +Partitioned Dataset (PDSE) Defaults:
 +
 +  Member Generations :@z  +(0 to 999)  System Limit:{sl
 +
-%Notes:+   The user.name and user.email are used to set email and
-+          username to your commits. The username does not need to be
-+          the same as your username.
+%Notes:+   The user.name and user.email are used to set username and
++          email to your commits. The username does not need to be
++          the same as your z/OS username.
 +
 +See : https://git-scm.com/book/en/v2/Getting-Started-First-Time-Git-Setup
 +


### PR DESCRIPTION
Increase the available characters for username and emails. I had issues
with the github autogenerated email for example.

Improve the description about what username and email are in the context
of git.