### PR TITLE
Translates (); in the .zigi/dsn

### DIFF
--- a/ZIGI.EXEC/ZIGICKOT
+++ b/ZIGI.EXEC/ZIGICKOT
@@ -17,6 +17,8 @@
   | Author:    Lionel B. Dyck                                  |
   |                                                            |
   | History:  (most recent on top)                             |
+  |            04/19/21 JAL - Translate (); in the .zigi/dsn   |
+  |                         - Prevents parameter injection     |
   |            02/24/21 LBD - Correct use of putpds for members|
   |            01/06/21 LBD - Ignore files not in .zigi/dsn    |
   |            11/19/20 LBD - Use -T for default cp copies     |
@@ -176,6 +178,7 @@
     zdsn. = null
     call outtrap 'off'
     do i = 1 to ck.0
+      ck.i = translate(ck.i,'???','();')
       if left(ck.i,1) = '#' then iterate
       if word(ck.i,1) = '*' then do
         parse value ck.i with . def_dsorg def_recfm def_lrecl def_blksize .


### PR DESCRIPTION
This prevents someone making a entry which can write outside the prefix like so
EVILDIR PO FB 80 32720)DS('JAKE.TEST');

There doesnt seem to be any benefit from allowing these characters so just translates all these characters into ?